### PR TITLE
Support for scroll restoration within a specified scroll container id

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ function App() { // This needs to be NextJS App Component
 }
 ```
 
+**If your app limits content scrolling within a particular DOM element only, rather than allowing normal full window scrolling, you can pass the scrollAreaId property **
+
+scrollAreaId is the id of the element that scrolls. If you have a div with id="divThatScrolls", you would pass scrollAreaId="divThatScrolls"
+
+```js
+import { useScrollRestoration } from 'next-restore-scroll-position';
+
+function App() { // This needs to be NextJS App Component
+    const router = useRouter();
+    useScrollRestoration(router, {scrollAreaId: "divThatScrolls"});
+}
+```
+
 **You can also disable the scroll restoration by passing `enabled` property**
 
 ```js

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ function App() { // This needs to be NextJS App Component
 }
 ```
 
-**If your app limits content scrolling to a particular DOM element**
+**If your app limits content scrolling to a particular DOM element.**
+
 When only a portion of the page scrolls, rather than normal full window scrolling, you can pass the `scrollAreaId` property
 
 scrollAreaId is the id of the element that scrolls. If you have a div with `id="divThatScrolls"`, you would pass scrollAreaId="divThatScrolls as in the following example."

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ function App() { // This needs to be NextJS App Component
 }
 ```
 
-**If your app limits content scrolling within a particular DOM element only, rather than allowing normal full window scrolling, you can pass the scrollAreaId property **
+**If your app limits content scrolling to a particular DOM element**
+When only a portion of the page scrolls, rather than normal full window scrolling, you can pass the `scrollAreaId` property
 
-scrollAreaId is the id of the element that scrolls. If you have a div with id="divThatScrolls", you would pass scrollAreaId="divThatScrolls"
+scrollAreaId is the id of the element that scrolls. If you have a div with `id="divThatScrolls"`, you would pass scrollAreaId="divThatScrolls as in the following example."
 
 ```js
 import { useScrollRestoration } from 'next-restore-scroll-position';

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ function App() { // This needs to be NextJS App Component
 
 When only a portion of the page scrolls, rather than normal full window scrolling, you can pass the `scrollAreaId` property
 
-scrollAreaId is the id of the element that scrolls. If you have a div with `id="divThatScrolls"`, you would pass scrollAreaId="divThatScrolls as in the following example."
+scrollAreaId is the id of the element that scrolls. If you have a div with `id="divThatScrolls"`, you would pass scrollAreaId="divThatScrolls" as in the following example.
 
 ```js
 import { useScrollRestoration } from 'next-restore-scroll-position';

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,19 +1,47 @@
 export const getStorage = () => sessionStorage
 
-export const saveScrollPos = (asPath: string) => {
-  try {
-    getStorage().setItem(`scrollPos:${asPath}`, JSON.stringify({ x: window.scrollX, y: window.scrollY }))
+export const saveScrollPos = (asPath: string, scrollAreaId:null|string) => {
+    try {
+        var scrollPos = null
+        if (scrollAreaId){
+            const scrollArea = document.getElementById(scrollAreaId)
+            if (scrollArea){
+                scrollPos = { x:scrollArea.scrollLeft , y: scrollArea.scrollTop }
+            } 
+        }else {
+            scrollPos = { x: window.scrollX, y: window.scrollY }
+        }
+
+        if(scrollPos){
+
+            getStorage().setItem(`scrollPos:${asPath}`, JSON.stringify(scrollPos))
+               
+        }
     // eslint-disable-next-line no-empty
-  } catch (error) {}
+    } catch (error) {}
 }
 
-export const restoreScrollPos = (asPath: string) => {
+export const restoreScrollPos = (asPath: string, scrollAreaId:null|string) => {
   try {
+
     const json = getStorage().getItem(`scrollPos:${asPath}`)
     const scrollPos = json ? JSON.parse(json) : undefined
-    if (scrollPos && scrollPos.y) {
-      window.scrollTo(scrollPos.x, scrollPos.y)
+
+    let scrollArea: HTMLElement|Window|null  = null
+    
+    if (scrollAreaId){
+        
+        
+        scrollArea = document.getElementById(scrollAreaId)
     }
+
+    if (!scrollArea){
+        scrollArea = window
+    } 
+    if (scrollPos && scrollArea && scrollPos.y) {
+        scrollArea.scrollTo(scrollPos.x, scrollPos.y)
+    }
+    
     // eslint-disable-next-line no-empty
   } catch (e) {}
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -3,7 +3,7 @@ export const getStorage = () => sessionStorage
 export const saveScrollPos = (asPath: string, scrollAreaId:null|string) => {
     try {
         let scrollPos = null
-        let scrollArea = null
+        let scrollArea: HTMLElement|null = null
 
         if (scrollAreaId){
             scrollArea = document.getElementById(scrollAreaId)

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -10,19 +10,13 @@ export const saveScrollPos = (asPath: string, scrollAreaId:null|string) => {
         }
 
         if (scrollArea){
-
             scrollPos = { x:scrollArea.scrollLeft , y: scrollArea.scrollTop }
-
         } else {
-
             scrollPos = { x: window.scrollX, y: window.scrollY }
-
         }
 
         if(scrollPos){
-
             getStorage().setItem(`scrollPos:${asPath}`, JSON.stringify(scrollPos))
-               
         }
 
     // eslint-disable-next-line no-empty
@@ -38,7 +32,6 @@ export const restoreScrollPos = (asPath: string, scrollAreaId:null|string) => {
     let scrollArea: HTMLElement|Window|null  = null
     
     if (scrollAreaId){
-        
         scrollArea = document.getElementById(scrollAreaId)
     }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,14 +2,21 @@ export const getStorage = () => sessionStorage
 
 export const saveScrollPos = (asPath: string, scrollAreaId:null|string) => {
     try {
-        var scrollPos = null
+        let scrollPos = null
+        let scrollArea = null
+
         if (scrollAreaId){
-            const scrollArea = document.getElementById(scrollAreaId)
-            if (scrollArea){
-                scrollPos = { x:scrollArea.scrollLeft , y: scrollArea.scrollTop }
-            } 
-        }else {
+            scrollArea = document.getElementById(scrollAreaId)
+        }
+
+        if (scrollArea){
+
+            scrollPos = { x:scrollArea.scrollLeft , y: scrollArea.scrollTop }
+
+        } else {
+
             scrollPos = { x: window.scrollX, y: window.scrollY }
+
         }
 
         if(scrollPos){
@@ -17,6 +24,7 @@ export const saveScrollPos = (asPath: string, scrollAreaId:null|string) => {
             getStorage().setItem(`scrollPos:${asPath}`, JSON.stringify(scrollPos))
                
         }
+
     // eslint-disable-next-line no-empty
     } catch (error) {}
 }
@@ -31,13 +39,13 @@ export const restoreScrollPos = (asPath: string, scrollAreaId:null|string) => {
     
     if (scrollAreaId){
         
-        
         scrollArea = document.getElementById(scrollAreaId)
     }
 
     if (!scrollArea){
         scrollArea = window
     } 
+
     if (scrollPos && scrollArea && scrollPos.y) {
         scrollArea.scrollTo(scrollPos.x, scrollPos.y)
     }


### PR DESCRIPTION
Some CSS techniques may limit scrolling within a specific div, rather than allowing the normal window level scrolling. In order to handle scroll restoration within such a scenario, an optional 'scrollAreaId' parameter is added to useScrollRestoration. If the parameter is set, and a div with that ID is found, then the scroll position of the specified div is saved/restored as needed.